### PR TITLE
Fix for future trajectory check during avoiding oscillations and update default parameters to match original version of the planner 

### DIFF
--- a/config/octomap_planner.yaml
+++ b/config/octomap_planner.yaml
@@ -20,7 +20,7 @@ min_path_length: 0.2 # [m] minimum length of path to be published
 min_path_heading_change: 0.1 # [rad] minimum change of heading in the path to be published
 max_attempts_to_replan: 2 # [-] maximum number of attempts to replan when a path is not found
 min_dist_to_goal_improvement: 1.0 # [m] minimum improvement in distance of final waypoint of the path to user goal in two consecutive replanning steps
-max_goal_dist_to_disable_replanning: 200.0 # [m] maximum distance for which the replanning can be disabled when there is a risk of oscillations (set to zero to disable mitigation of oscillations)
+max_goal_dist_to_disable_replanning: 2.0 # [m] maximum distance for which the replanning can be disabled when there is a risk of oscillations (set to zero to disable mitigation of oscillations)
 use_user_heading_for_final_point: false # if true, final point with user heading is appended to every publish path, can lead to deviation from required heading when used in combination with changing heading in direction of flight
 
 distance_penalty: 1.0 # coefficient for traveled distance from start in A* cost function


### PR DESCRIPTION
This pull request includes important changes that fixes future trajectory to be always active during the flight independently on parameter values and updates the default configuration files to match the behavior of the original version of the planner before addition of the changes mentioned below.

The key important changes already unintentionally merged in the previous pull request are:  
- the reference goal for the planner can be send in arbitrary valid reference frame
- the planner allows to generate trajectories that change heading to the value provided as a user-defined goal independently on the size of translation (including rotation without any translation)
- the planner enables to reach the final heading independently on the use of perception-aware heading control
- the virtual obstacles in the form of rhomboid prism can be added as untraversable areas in the environment
- the planner avoids oscillations around the current position during replanning to unreachable goal 
- fixed deadlocks for certain values of safety distance due to comparison of double with float
- avoid deadlocks due to incorrect setting of EDF cutoff distance by replacing this parameter with setting of EDF cutoff distance based on user-defined safety distance 